### PR TITLE
Move react dependency to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mocha": "^2.2.5",
     "commonmark": "^0.19.0"
   },
-  "dependencies": {
-    "react": "^0.13.3"
+  "peerDependencies": {
+    "react": ">=0.13.3"
   }
 }


### PR DESCRIPTION
In order to maintain compatibility with projects using react v0.14.0, we want to use the react version installed on the owner's project. This also prevents a separate version of react being packaged with react-markdown.