### PR TITLE
Custom renderers

### DIFF
--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -8,6 +8,15 @@ function element(tagName, props, children) {
     return child;
 }
 
+// NOTE: not completely safe, but should deter most cases
+function isPlainObject(target) {
+    return (
+        target &&
+        typeof target === 'object' &&
+        !Array.isArray(target)
+    );
+}
+
 // NOTE: using objects as sets for O(1) lookups
 function makeSet(array) {
     var set = {};
@@ -184,7 +193,7 @@ function renderNodes(block) {
         }
 
         // Getting the correct renderer
-        render = renderers[type];
+        render = this.renderers[type];
 
         if (type !== 'Document') {
             if (!render) {
@@ -266,6 +275,7 @@ function replaceDeprecatedType(type) {
 
 function ReactRenderer(options) {
     var opts = options || {};
+    var k;
 
     if (opts.allowedTypes && opts.disallowedTypes) {
         throw new Error('Only one of `allowedTypes` and `disallowedTypes` should be defined');
@@ -293,6 +303,20 @@ function ReactRenderer(options) {
 
     var allowedTypesSet = makeSet(allowedTypes);
 
+    if (opts.renderers && !isPlainObject(opts.renderers)) {
+        throw new Error('`renderers` must be a plain object');
+    }
+
+    var customRenderers = null;
+
+    if (opts.renderers) {
+        customRenderers = {};
+
+        for (k in renderers) {
+            customRenderers[k] = opts.renderers[k] || renderers[k];
+        }
+    }
+
     return {
         sourcePos: opts.sourcePos,
         softBreak: opts.softBreak || '\n',
@@ -301,6 +325,7 @@ function ReactRenderer(options) {
         allowNode: opts.allowNode,
         allowedTypes: allowedTypes,
         allowedTypesSet: allowedTypesSet,
+        renderers: customRenderers || renderers,
         render: renderNodes
     };
 }

--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -102,12 +102,13 @@ var renderers = {
     },
     CodeBlock: function(node, props, children) {
         var infoWords = node.info ? node.info.split(/ +/) : [];
+        var codeProps = {};
         if (infoWords.length > 0 && infoWords[0].length > 0) {
-            props.className = 'language-' + infoWords[0];
+            codeProps.className = 'language-' + infoWords[0];
         }
 
-        var code = element('code', props, children);
-        return element('pre', null, code);
+        var code = element('code', codeProps, children);
+        return element('pre', props, code);
     },
     BlockQuote: function(node, props, children) {
         return element('blockquote', props, children);

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,6 @@
 {
     "rules": {
-        "no-unused-expressions": 0
+        "no-unused-expressions": 0,
+        "react/no-multi-comp": 0
     }
 }

--- a/test/commonmark-react-renderer.js
+++ b/test/commonmark-react-renderer.js
@@ -298,6 +298,12 @@ describe('react-markdown', function() {
         }).to.throw(Error, /allowNode.*?function/i);
     });
 
+    it('should throw if `renderers` is not a plain object', function() {
+        expect(function() {
+            parse('', { renderers: [1, 2] });
+        }).to.throw(Error, /renderers.*?object/i);
+    });
+
     it('should be able to use a custom function to determine if the node should be allowed', function() {
         var input = '# Header\n\n[react-markdown](https://github.com/rexxars/react-markdown/) is a nice helper\n\n';
         input += 'Also check out [my website](https://espen.codes/)';
@@ -312,6 +318,30 @@ describe('react-markdown', function() {
             '<h1>Header</h1><p>',
             ' is a nice helper</p><p>Also check out </p>'
         ].join(''));
+    });
+
+    it('should be possible to override default renderers.', function() {
+        var customRenderers = {
+            Strong: function(node, props, children) {
+                return React.createElement('b', props, children);
+            },
+            Text: function() {
+                return 'Placeholder';
+            },
+            Paragraph: function(node, props, children) {
+                return React.createElement('section', props, children);
+            }
+        };
+
+        var input = 'This is some *important* text.';
+
+        var output = parse(input, {
+            renderers: customRenderers
+        });
+
+        expect(output).to.equal(
+            '<section>Placeholder<em>Placeholder</em>Placeholder</section>'
+        );
     });
 });
 

--- a/test/commonmark-react-renderer.js
+++ b/test/commonmark-react-renderer.js
@@ -59,13 +59,7 @@ describe('react-markdown', function() {
 
     it('should handle images without title tags', function() {
         var input = 'This is ![an image](/ninja.png).';
-        var expected = '<p>This is <img src="/ninja.png" alt="an image"/>.</p>';
-        expect(parse(input)).to.equal(expected);
-    });
-
-    it('should handle images without title tags', function() {
-        var input = 'This is ![an image](/ninja.png "foo bar").';
-        var expected = '<p>This is <img src="/ninja.png" title="foo bar" alt="an image"/>.</p>';
+        var expected = '<p>This is <img alt="an image" src="/ninja.png"/>.</p>';
         expect(parse(input)).to.equal(expected);
     });
 
@@ -310,12 +304,12 @@ describe('react-markdown', function() {
 
         var output = parse(input, {
             allowNode: function(node) {
-                return node.type !== 'Link' || node.props.href.indexOf('https://github.com/') === 0;
+                return node.type !== 'Link';
             }
         });
 
         expect(output).to.equal([
-            '<h1>Header</h1><p><a href="https://github.com/rexxars/react-markdown/">react-markdown</a>',
+            '<h1>Header</h1><p>',
             ' is a nice helper</p><p>Also check out </p>'
         ].join(''));
     });


### PR DESCRIPTION
Hello @rexxars. Sorry for this PR a bit heavy but I tried to follow up on the ideas of #5 and updated your code to be able to handle custom renderers for every types.

A rendering function has therefore the following signature:

```jsx
function renderParagraph(node, props, children, opts) {

  // node is the commonmark parser node
  // props are the renderer's pre-computed props such as keys etc.
  // children are the component's children
  // opts are the renderer's options

  // the function must simply return a react element
  return <p {...props}>{children}</p>;
}
```

You can then pass your custom renderers likewise:

```jsx
var renderer = new ReactRenderer({
  renderers: {
    Strong: function(node, props, children) {
      return React.createElement('b', props, children);
    },
    Text: function() {
      return 'Placeholder';
    },
    Paragraph: function(node, props, children) {
      return React.createElement('section', props, children);
    }
  }
});

// will render "This is some *important* text."
// into "<section>Placeholder<em>Placeholder</em>Placeholder</section>"
```

This has some collateral benefits: one can now very easily highlight code (without the lib imposing a precise method on him). I will probably, for instance, develop a code renderer using [highlight.js](https://highlightjs.org/) on a project when have with @glenjamin.

Plus, node type solving is now `O(1)`, compared to the `O(n)` switch statement and while the number of function calls has increased a bit, this should somewhat increase the renderer's performance.

What still remains to be discussed with this solution however is what should be passed to the `allowNode` function.

Here it is :). If you like it and find it suitable, I can also edit the PR to add some docs about custom rendering.