### PR TITLE
Update use of alternative text when rendering an image

### DIFF
--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -131,7 +131,7 @@ function getNodeProps(node, key, opts, undef) {
             props.title = node.title || undef;
 
             // Commonmark treats image description as children. We just want the text
-            props.alt = node.react.children[0];
+            props.alt = node.react.children.join('');
             node.react.children = undef;
             break;
         case 'List':

--- a/test/commonmark-react-renderer.test.js
+++ b/test/commonmark-react-renderer.test.js
@@ -83,6 +83,12 @@ describe('react-markdown', function() {
         expect(parse(input)).to.equal(expected);
     });
 
+    it('should handle images without special characters in alternative text', function() {
+        var input = 'This is ![a ninja\'s image](/ninja.png).';
+        var expected = '<p>This is <img src="/ninja.png" alt="a ninja&#x27;s image"/>.</p>';
+        expect(parse(input)).to.equal(expected);
+    });
+
     it('should be able to render headers', function() {
         expect(parse('# Awesome')).to.equal('<h1>Awesome</h1>');
         expect(parse('## Awesome')).to.equal('<h2>Awesome</h2>');

--- a/test/commonmark-react-renderer.test.js
+++ b/test/commonmark-react-renderer.test.js
@@ -77,7 +77,7 @@ describe('react-markdown', function() {
         expect(parse(input)).to.equal(expected);
     });
 
-    it('should handle images without title tags', function() {
+    it('should handle images with title tags', function() {
         var input = 'This is ![an image](/ninja.png "foo bar").';
         var expected = '<p>This is <img src="/ninja.png" title="foo bar" alt="an image"/>.</p>';
         expect(parse(input)).to.equal(expected);


### PR DESCRIPTION
First – thanks for taking the time to make this awesome library and [`react-markdown`](https://github.com/rexxars/react-markdown) !!

Second – when rendering `<img>` elements the alternative text attribute is set as the first element of an array with the comment `"Commonmark treats image description as children. We just want the text"`. Some characters (HTML entities, some punctuation, etc) can cause this text to be truncated [so instead of selecting the first element](https://github.com/rexxars/commonmark-react-renderer/blob/62bef9f5ed79efedd8429e8570d0ed9f8bf6fa92/src/commonmark-react-renderer.js#L133-L134) I'd like to suggest using the full original string with the change in this PR.

The case for this becomes more obvious when you want to create an alternate rendering method. Consider the following samples based on an alternative image renderer component, the `CaptionImage`:
```
const CaptionImage = (props) => (
  <span>
    <img alt={props.alt} src={props.src} />
    <span className="img-caption">{props.alt}</span>
  </span>
);
```

### Before the proposed fix:
<img width="669" alt="before" src="https://cloud.githubusercontent.com/assets/1141187/14839718/449d9e86-0bfb-11e6-9f96-ea31ff8d1d68.png">
```
props.alt == "When we take the position that it is not only the programmer";
```

### After the proposed fix:
<img width="670" alt="after" src="https://cloud.githubusercontent.com/assets/1141187/14839716/41303aa6-0bfb-11e6-86e4-276d9a172900.png">
```
props.alt == "When we take the position that it is not only the programmer's responsibility to produce a correct program but also to demonstrate its correctness in a convincing manner, then the above remarks have a profound influence on the programmer's activity: the object he has to produce must be usefully structured.";
```