### PR TITLE
Need all of CodeBlock language line in renderer

### DIFF
--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -151,6 +151,7 @@ function getNodeProps(node, key, opts, renderer) {
             var codeInfo = node.info ? node.info.split(/ +/) : [];
             if (codeInfo.length > 0 && codeInfo[0].length > 0) {
                 props.language = codeInfo[0];
+                props.codeinfo = codeInfo;
             }
             break;
         case 'code':

--- a/test/commonmark-react-renderer.test.js
+++ b/test/commonmark-react-renderer.test.js
@@ -399,7 +399,7 @@ describe('react-markdown', function() {
             }
         }).replace(/&quot;/g, '"')).to.equal([
             '<div class="level-1">Header</div><hr/><p>Paragraph a day...</p>',
-            '<pre>{"language":"js","literal":"var keepTheDoctor = \\"away\\";\\n","nodeKey":"4:1-6:27"}</pre>',
+            '<pre>{"language":"js","codeinfo":["js"],"literal":"var keepTheDoctor = \\"away\\";\\n","nodeKey":"4:1-6:27"}</pre>',
             '<blockquote><p>Foo</p></blockquote>'
         ].join(''));
     });


### PR DESCRIPTION
I often use the language line of a code block as a way to pass data:

```
​```example jsx
<MyComponent>contents</MyComponent>
​```
```

Unfortunately, the `commonmark-react-renderer` implementation only retains the first word. In other words, only `example` is passed in `props.language`. This is because the following code only adds `codeInfo[0]` to the properties:
https://github.com/rexxars/commonmark-react-renderer/blob/master/src/commonmark-react-renderer.js#L153

For backward compatibility and ease of use, I don't think the value of `props.language` should change. But perhaps an additional property could be added:

```
        case 'code_block':
            var codeInfo = node.info ? node.info.split(/ +/) : [];
            if (codeInfo.length > 0 && codeInfo[0].length > 0) {
                props.language = codeInfo[0];
                props.codeinfo = codeInfo;
            }
            break;
```

This seems like a simple fix. so I've created a PR for it.