### PR TITLE
Fix key prop warning with React 16.0.0

### DIFF
--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -217,20 +217,13 @@ function getPosition(node) {
 function renderNodes(block) {
     var walker = block.walker();
 
-    // Softbreaks are usually treated as newlines, but in HTML we might want explicit linebreaks
-    var softBreak = (
-        this.softBreak === 'br' ?
-        React.createElement('br') :
-        this.softBreak
-    );
-
     var propOptions = {
         sourcePos: this.sourcePos,
         escapeHtml: this.escapeHtml,
         skipHtml: this.skipHtml,
         transformLinkUri: this.transformLinkUri,
         transformImageUri: this.transformImageUri,
-        softBreak: softBreak,
+        softBreak: this.softBreak,
         linkTarget: this.linkTarget
     };
 
@@ -323,6 +316,12 @@ function renderNodes(block) {
             } else if (type === 'text') {
                 addChild(node, node.literal);
             } else if (type === 'softbreak') {
+                // Softbreaks are usually treated as newlines, but in HTML we might want explicit linebreaks
+                var softBreak = (
+                    this.softBreak === 'br' ?
+                    React.createElement('br', {key: key}) :
+                    this.softBreak
+                );
                 addChild(node, softBreak);
             }
         }

--- a/test/commonmark-react-renderer.test.js
+++ b/test/commonmark-react-renderer.test.js
@@ -41,6 +41,16 @@ describe('react-markdown', function() {
         expect(parse(input, { softBreak: 'br' })).to.equal(expected);
     });
 
+    it('should add a key to generated <br/> children', function() {
+        var input = 'React is awesome\nAnd so is markdown\n\nCombining = epic';
+        var ast = parser.parse(input);
+        var result = getRenderer({ softBreak: 'br' }).render(ast);
+        var allHaveKeys = extractChildren(result).every(function(el) {
+            return el.key !== null;
+        });
+        expect(allHaveKeys).to.equal(true);
+    });
+
     it('should handle multi-space+break as hardbreak', function() {
         var input = 'React is awesome  \nAnd so is markdown';
         var expected = '<p>React is awesome<br/>And so is markdown</p>';
@@ -577,6 +587,16 @@ describe('react-markdown', function() {
         });
     });
 });
+
+function extractChildren(elements, allChildren) {
+    var validElements = elements.filter(React.isValidElement);
+    return validElements.reduce(function(acc, current) {
+        var children = current.props.children;
+        return typeof children !== 'undefined'
+            ? extractChildren(children, acc).concat(current)
+            : acc.concat(current);
+    }, allChildren || []);
+}
 
 function getRenderer(opts) {
     if (opts) {


### PR DESCRIPTION
Hiya,

When using React@16.0.0, `<br/>` children generated via `{softBreak: true}` are throwing warnings due to not having a `key`. 

This fixes that and also maintains compatibility with React@15.6.2. I also went ahead and added a test to cover any potential regressions on the matter.

This PR closes #34 and makes progress toward fixing rexxars/react-markdown#88 (should just need to update deps once commonmark-react-renderer is updated).

Let me know if there are any changes you'd like and I'll accommodate asap.

Cheers

