### PR TITLE
Add data-attributes to coreProps

### DIFF
--- a/src/commonmark-react-renderer.js
+++ b/src/commonmark-react-renderer.js
@@ -58,11 +58,25 @@ var defaultRenderers = {
 var coreTypes = Object.keys(defaultRenderers);
 
 function getCoreProps(props) {
-    return {
-        'key': props.nodeKey,
-        'className': props.className,
-        'data-sourcepos': props['data-sourcepos']
+    var propKeys = Object.keys(props);
+
+    var dataPropKeys = propKeys.filter(function(propKey) {
+        return propKey.match(/data-.*/g);
+    });
+
+    var base = {
+        key: props.nodeKey,
+        className: props.className
     };
+
+    var dataAttributes = dataPropKeys.reduce(function(prev, dataPropKey) {
+        var attributes = {};
+        attributes[dataPropKey] = props[dataPropKey];
+
+        return assign(attributes, prev);
+    }, {});
+
+    return assign(dataAttributes, base);
 }
 
 function normalizeTypeName(typeName) {

--- a/test/commonmark-react-renderer.test.js
+++ b/test/commonmark-react-renderer.test.js
@@ -522,6 +522,28 @@ describe('react-markdown', function() {
         });
     });
 
+    describe('should allow data attributes to be passed', function() {
+        function addDataId(result) {
+            return React.cloneElement(result[0], {'data-id': 'test'});
+        }
+
+        it('lists', function() {
+            expect(parse('3. Foo\n4. Bar', {}, addDataId))
+                .to.contain('<ol data-id="test" start="3">');
+        });
+
+        it('codeblocks', function() {
+            expect(parse('```js\nvar foo = bar;\n```', {}, addDataId))
+                .to.contain('<pre data-id="test">');
+        });
+
+        it('headings', function() {
+            expect(parse('# Foo', {}, addDataId)).to.contain('<h1 data-id="test">');
+            expect(parse('## Foo', {}, addDataId)).to.contain('<h2 data-id="test">');
+            expect(parse('### Foo', {}, addDataId)).to.contain('<h3 data-id="test">');
+        });
+    });
+
     describe('should only pass necessary props onto plain dom element renderers', function() {
         it('should pass only children onto blockquote', function() {
             expect(parse('> Foo\n> Bar\n> Baz\n')).to.contain('<blockquote><p>Foo');
@@ -629,12 +651,13 @@ function getFakeWalker() {
     };
 }
 
-function parse(markdown, opts) {
+function parse(markdown, opts, modifyResult) {
     var ast = parser.parse(markdown);
     var result = getRenderer(opts).render(ast);
+    var maybeModifiedResult = modifyResult ? modifyResult(result) : result;
 
     var html = renderHtml.renderToStaticMarkup(
-        React.createElement.apply(React, ['div', null].concat(result))
+        React.createElement.apply(React, ['div', null].concat(maybeModifiedResult))
     );
 
     return html.substring('<div>'.length, html.length - '</div>'.length);


### PR DESCRIPTION
# Rationale
We do functional (aka end-to-end) tests which rely on being able to find certain selectors to make assertions. We particularly like being able to use `data-id` as an attribute on elements so we can avoid writing confusing selectors. It's like using `id` but more React friendly as it doesn't have to be truly unique.

# Key points
In this PR I have extended the `getCoreProps` function to allow `data-` attributes to be passed through as props.

I hope you consider this PR as it would greatly improve our QOL. Thanks