### PR TITLE
Update commonmark compatibility range

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "react": ">=0.14.0",
-    "commonmark": "^0.27.0 || ^0.26.0 || ^0.24.0"
+    "commonmark": ">=0.24.0 <0.30.0"
   },
   "dependencies": {
     "lodash.assign": "^4.2.0",


### PR DESCRIPTION
I've been running this package with commonmark 0.29.1 for a while. It works fine, but produces a peer dependency error every time I run `yarn` or `npm install`.

I think the peer dependency range can be safely updated to be a true range instead of having to list every minor version separately.