### PR TITLE
Upgrade commonmark to avoid minor vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^3.4.0",
-    "commonmark": "^0.27.0",
+    "commonmark": "^0.29.1",
     "eslint": "^1.7.3",
     "eslint-config-vaffel": "^3.0.0",
     "eslint-plugin-react": "^3.6.3",
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "react": ">=0.14.0",
-    "commonmark": "^0.27.0 || ^0.26.0 || ^0.24.0"
+    "commonmark": "^0.29.1 || ^0.27.0 || ^0.26.0 || ^0.24.0"
   },
   "dependencies": {
     "lodash.assign": "^4.2.0",

--- a/test/commonmark-react-renderer.test.js
+++ b/test/commonmark-react-renderer.test.js
@@ -410,7 +410,7 @@ describe('react-markdown', function() {
         }).replace(/&quot;/g, '"')).to.equal([
             '<div class="level-1">Header</div><hr/><p>Paragraph a day...</p>',
             '<pre>{"language":"js","codeinfo":["js"],"literal":',
-            '"var keepTheDoctor = \\"away\\";\\n","nodeKey":"4:1-6:27"}</pre>',
+            '"var keepTheDoctor = \\"away\\";\\n","nodeKey":"4:1-6:3"}</pre>',
             '<blockquote><p>Foo</p></blockquote>'
         ].join(''));
     });
@@ -512,7 +512,7 @@ describe('react-markdown', function() {
 
         it('codeblocks', function() {
             expect(parse('```js\nvar foo = bar;\n```', {sourcePos: true}))
-                .to.contain('<pre data-sourcepos="1:1-3:14">');
+                .to.contain('<pre data-sourcepos="1:1-3:3">');
         });
 
         it('headings', function() {


### PR DESCRIPTION
commonmark 0.27.0 has a denial-of-service vulnerability in the form of some inefficient parsing that takes quadratic time, as documented here: commonmark/commonmark.js#172 .  This was fixed in commonmark 0.29.1, so this PR upgrades to that version. 

This did require some small updates to the tests.  It's not clear to me whether those updates were something to be expected or if they are a problem.  I suspect they are fine, but please check them closely while reviewing.